### PR TITLE
Fix device-layer bugs in humidity, fan, and online handling

### DIFF
--- a/src/AprilaireDehumidifier.ts
+++ b/src/AprilaireDehumidifier.ts
@@ -12,13 +12,12 @@ export class AprilaireDehumidifier extends AprilaireThermostatBase implements On
         super(nativeId, client, AprilaireSystemType.Dehumidifier);
     }
 
-    setFan(fan: FanState): Promise<void> {
-        if (fan.speed) {
-            if (fan.speed === 0)
-                return this.turnOff();
-            else
-                return this.turnOn();
-        }
+    async setFan(fan: FanState): Promise<void> {
+        if (fan.speed === undefined)
+            return;
+        if (fan.speed === 0)
+            return this.turnOff();
+        return this.turnOn();
     }
 
     async turnOff(): Promise<void> {
@@ -30,35 +29,32 @@ export class AprilaireDehumidifier extends AprilaireThermostatBase implements On
     async turnOn(): Promise<void> {
         let hrequest = new DehumidificationSetpointRequest();
         hrequest.on = true;
-        hrequest.dehumidificationSetpoint = this.humiditySetting.humidifierSetpoint;
+        hrequest.dehumidificationSetpoint = this.humiditySetting?.dehumidifierSetpoint ?? 0;
         this.client.write(hrequest);
     }
 
     async setHumidity(humidity: HumidityCommand): Promise<void> {
         let drequest = new DehumidificationSetpointRequest();
 
-        if (humidity.dehumidifierSetpoint) {
-            drequest.dehumidificationSetpoint = humidity.dehumidifierSetpoint;
-        }
+        drequest.dehumidificationSetpoint =
+            humidity.dehumidifierSetpoint ?? this.humiditySetting?.dehumidifierSetpoint ?? 0;
 
         if (humidity.mode) {
             switch (humidity.mode) {
-                case HumidityMode.Off:
-                    drequest.on = false;
-                    break;
-
                 case HumidityMode.Auto:
-                    drequest.on = true;
-                    break;
-
                 case HumidityMode.Dehumidify:
                     drequest.on = true;
                     break;
 
-                case HumidityMode.Humidify:
+                default:
                     drequest.on = false;
                     break;
             }
+        } else {
+            // Setpoint-only change: keep the current on/off state. The wire
+            // encodes off as setpoint 0, so leaving `on` unset would turn the
+            // unit off when the user only moves the humidity slider.
+            drequest.on = this.humiditySetting?.mode === HumidityMode.Dehumidify;
         }
 
         this.client.write(drequest);
@@ -101,7 +97,7 @@ export class AprilaireDehumidifier extends AprilaireThermostatBase implements On
         else if (response instanceof ThermostatAndIAQAvailableResponse) {
             let modes: HumidityMode[] = [HumidityMode.Off];
             if (response.dehumidification)
-                modes.push(HumidityMode.Humidify);
+                modes.push(HumidityMode.Dehumidify);
 
             humiditySetting.availableModes = modes;
             this.console.info("dehumidity modes: " + humiditySetting.availableModes);

--- a/src/AprilaireHumidifier.ts
+++ b/src/AprilaireHumidifier.ts
@@ -11,13 +11,12 @@ export class AprilaireHumidifier extends AprilaireThermostatBase implements OnOf
         super(nativeId, client, AprilaireSystemType.Humidifier);
     }
 
-    setFan(fan: FanState): Promise<void> {
-        if (fan.speed) {
-            if (fan.speed === 0)
-                return this.turnOff();
-            else
-                return this.turnOn();
-        }
+    async setFan(fan: FanState): Promise<void> {
+        if (fan.speed === undefined)
+            return;
+        if (fan.speed === 0)
+            return this.turnOff();
+        return this.turnOn();
     }
 
     async turnOff(): Promise<void> {
@@ -35,35 +34,32 @@ export class AprilaireHumidifier extends AprilaireThermostatBase implements OnOf
 
         let hrequest = new HumidificationSetpointRequest();
         hrequest.on = true;
-        hrequest.humidificationSetpoint = this.humiditySetting.humidifierSetpoint;
+        hrequest.humidificationSetpoint = this.humiditySetting?.humidifierSetpoint ?? 0;
         this.client.write(hrequest);
     }
 
     async setHumidity(humidity: HumidityCommand): Promise<void> {
         let hrequest = new HumidificationSetpointRequest();
 
-        if (humidity.humidifierSetpoint) {
-            hrequest.humidificationSetpoint = humidity.humidifierSetpoint;
-        }
+        hrequest.humidificationSetpoint =
+            humidity.humidifierSetpoint ?? this.humiditySetting?.humidifierSetpoint ?? 0;
 
         if (humidity.mode) {
             switch (humidity.mode) {
-                case HumidityMode.Off:
-                    hrequest.on = false;
-                    break;
-
                 case HumidityMode.Auto:
-                    hrequest.on = true;
-                    break;
-
-                case HumidityMode.Dehumidify:
-                    hrequest.on = false;
-                    break;
-
                 case HumidityMode.Humidify:
                     hrequest.on = true;
                     break;
+
+                default:
+                    hrequest.on = false;
+                    break;
             }
+        } else {
+            // Setpoint-only change: keep the current on/off state. The wire
+            // encodes off as setpoint 0, so leaving `on` unset would turn the
+            // unit off when the user only moves the humidity slider.
+            hrequest.on = this.humiditySetting?.mode === HumidityMode.Humidify;
         }
 
         this.client.write(hrequest);

--- a/src/AprilaireThermostat.ts
+++ b/src/AprilaireThermostat.ts
@@ -107,12 +107,23 @@ export class AprilaireThermostat extends AprilaireThermostatBase implements OnOf
     }
 
     async setFan(fan: FanState): Promise<void> {
+        // Explicit mode wins; otherwise infer from speed (>0 = manual/on, 0 = auto).
+        let mode: FanMode;
+        if (fan.mode !== undefined)
+            mode = fan.mode === FanMode.Auto ? FanMode.Auto : FanMode.Manual;
+        else if (fan.speed !== undefined)
+            mode = fan.speed > 0 ? FanMode.Manual : FanMode.Auto;
+        else
+            return;
+
         var setting = {...this.fan};
-        setting.mode = fan.mode === FanMode.Auto ? FanMode.Auto : FanMode.Manual;
-        setting.speed = fan.mode === FanMode.Auto ? 1 : 0;
+        setting.mode = mode;
+        // Manual = fan forced on; in Auto the ThermostatStatus COS reports actual state.
+        setting.speed = mode === FanMode.Manual ? 1 : 0;
+        setting.active = mode === FanMode.Manual;
 
         let request = new ThermostatSetpointAndModeSettingsRequest();
-        request.fan = fan.mode === FanMode.Auto ? FanModeSetting.Auto : FanModeSetting.On;
+        request.fan = mode === FanMode.Auto ? FanModeSetting.Auto : FanModeSetting.On;
 
         this.fan = setting;
         this.client.write(request);

--- a/src/AprilaireThermostatBase.ts
+++ b/src/AprilaireThermostatBase.ts
@@ -36,6 +36,11 @@ export class AprilaireThermostatBase extends ScryptedDeviceBase implements Onlin
             availableModes: [FanMode.Auto, FanMode.Manual]
         };
 
+        // Devices are constructed after the client's "ready", so start online.
+        this.online = true;
+        this.client.on("connected", () => { this.online = true; });
+        this.client.on("disconnected", () => { this.online = false; });
+
         // ensure that the modes are properly configured
         this.processResponse(client.system);
         this.client.on("response", this.processResponse.bind(this));
@@ -120,7 +125,9 @@ export class AprilaireThermostatBase extends ScryptedDeviceBase implements Onlin
         }
 
         else if (response instanceof OfflineResponse) {
-            this.on = response.offline === false;
+            // Status/Offline reports protocol availability — reflect it on the
+            // Online interface, not OnOff (it is not a power state).
+            this.online = response.offline === false;
         }
     }
 }


### PR DESCRIPTION
## What changed

Six correctness fixes in the Scrypted device layer, found during a full codebase review. No protocol/wire-format changes.

**Dehumidifier** (`AprilaireDehumidifier.ts`)
- `turnOn()` wrote `humiditySetting.humidifierSetpoint` (never populated on this device) as the dehumidification setpoint — effectively sending 0 (= off) on the wire. Now uses `dehumidifierSetpoint` with a `?? 0` guard against `writeUint8(undefined)` throws.
- `ThermostatAndIAQAvailableResponse` handling pushed `HumidityMode.Humidify` as the available mode; now correctly `Dehumidify`.

**Humidifier + dehumidifier**
- `setHumidity` with only a setpoint (no `mode`) left `request.on` undefined, which serializes as 0 = off — moving the humidity slider turned the equipment off. `on` now defaults to the device's current mode state, and the setpoint falls back to stored state.
- `setFan` was guarded with `if (fan.speed)`, making the `speed === 0` turn-off branch unreachable and returning `undefined` from a `Promise<void>` method. Speed 0 now turns off, nonzero turns on, missing speed is a no-op.

**Thermostat** (`AprilaireThermostat.ts`)
- `setFan` set local state inverted (speed 1 for Auto, 0 for Manual) and ignored speed-only commands. Manual now reports speed 1/active true, and mode is inferred from speed (>0 = Manual/On) when the command has no mode. The wire request was already correct; only Scrypted state was wrong.

**Online state** (`AprilaireThermostatBase.ts`)
- The base class declared `implements Online` but nothing ever set `this.online`. Devices now start online (constructed after client `"ready"`) and track the client's `"connected"`/`"disconnected"` events.
- `OfflineResponse` previously set `this.on` (the OnOff power property), making a protocol offline event look like the thermostat was switched off. It now sets `online`.

## Reviewer notes

- **Behavior change to be aware of:** any automation keyed off the thermostat's OnOff state going false during an outage will no longer fire — that signal moved to the `online` property, where Scrypted expects it.
- The mode `switch` blocks in `setHumidity` were collapsed to the two "on" cases plus a `default`; behavior-identical to the previous four explicit cases.
- Existing suite passes (204/204) and `tsc --noEmit` is clean. The protocol tests don't exercise these device-layer paths; a device-layer harness was attempted but backed out by request — the blocker was vitest inlining `@scrypted/sdk`'s CJS bundle as ESM (needs a `deps.external` tweak in `vitest.config.ts` if picked up later).

🤖 Generated with [Claude Code](https://claude.com/claude-code)