### PR TITLE
Run tests and production build on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+# Run unit tests and a production build for every pull request and push to main.
+#
+# Mirrors the build job in npm-publish.yml so a PR can't merge anything the
+# release pipeline would fail on.
+
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+# Cancel superseded runs when a PR is force-pushed or updated.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Unit tests
+        run: npm test
+
+      - name: Production webpack bundle
+        run: npm run prepublishOnly
+
+      - name: Verify plugin artifact
+        run: |
+          test -f dist/plugin.zip
+          ls -la dist/


### PR DESCRIPTION
## What changed

Adds `.github/workflows/ci.yml`, triggered on every `pull_request` and on pushes to `main`. It mirrors the `build` job from `npm-publish.yml` so a PR can't merge anything the release pipeline would later fail on:

1. `npm ci`
2. `npm test` (vitest, 204 protocol unit tests)
3. `NODE_ENV=production` webpack bundle via `prepublishOnly`
4. Verify `dist/plugin.zip` exists

Superseded runs on the same ref are cancelled (`concurrency`), and the workflow only needs `contents: read`.

## Reviewer notes

- Node 22 with npm cache, matching the publish workflow.
- To make the check *required* (block merging on failure), enable branch protection on `main` requiring the `test` check after this merges — that's a repo setting, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)