### PR TITLE
Fix response timestamp and Away Settings map holes

### DIFF
--- a/src/BasePayloadResponse.ts
+++ b/src/BasePayloadResponse.ts
@@ -2,7 +2,7 @@ import { FunctionalDomain, FunctionalDomainControl, FunctionalDomainIdentificati
 
 
 export class BasePayloadResponse {
-    timestamp = Date.now;
+    timestamp = Date.now();
 
     payload: Buffer;
     responseError: ResponseErrorType;

--- a/src/FunctionalDomainScheduling.ts
+++ b/src/FunctionalDomainScheduling.ts
@@ -208,6 +208,21 @@ export class HeatBlastResponse extends BasePayloadResponse {
     }
 }
 
+/** Away Settings heat setpoint by wire index (guide §3.2). */
+export const AWAY_HEAT_SETPOINTS_C = [15.5, 16, 16.5, 17, 17.5, 18.5] as const;
+/** Away Settings cool setpoint by wire index (guide §3.2). */
+export const AWAY_COOL_SETPOINTS_C = [26.5, 27, 27.5, 28.5, 29, 29.5] as const;
+
+/** Nearest wire index for a Celsius value; ties round up. */
+function nearestAwayIndex(values: readonly number[], celsius: number): number {
+    let best = 0;
+    for (let i = 1; i < values.length; i++) {
+        if (Math.abs(values[i] - celsius) <= Math.abs(values[best] - celsius))
+            best = i;
+    }
+    return best;
+}
+
 export class AwaySettingsResponse extends BasePayloadResponse {
     fan: FanModeSetting;
     heatSetpoint: number;
@@ -215,27 +230,13 @@ export class AwaySettingsResponse extends BasePayloadResponse {
     constructor(payload: Buffer) {
         super(payload, FunctionalDomain.Scheduling, FunctionalDomainScheduling.AwaySettings);
 
-        const awayHeatMap = {
-            0: 15.5,
-            1: 16,
-            2: 16.5,
-            3: 17,
-            4: 17.5,
-            5: 18.5
-        };
-        
-        const awayCoolMap = {
-            0: 26.5,
-            1: 27,
-            2: 27.5,
-            3: 28.5,
-            4: 29,
-            5: 29.5
-        };
-
         this.fan = payload.readUint8(0);
-        this.heatSetpoint = awayHeatMap[payload.readUint8(1)];
-        this.coolSetpoint = awayCoolMap[payload.readUint8(2)];
+        // Clamp out-of-range wire indices to the table bounds so the parsed
+        // setpoints are always numbers, never undefined.
+        const heatIndex = Math.min(payload.readUint8(1), AWAY_HEAT_SETPOINTS_C.length - 1);
+        const coolIndex = Math.min(payload.readUint8(2), AWAY_COOL_SETPOINTS_C.length - 1);
+        this.heatSetpoint = AWAY_HEAT_SETPOINTS_C[heatIndex];
+        this.coolSetpoint = AWAY_COOL_SETPOINTS_C[coolIndex];
     }
 }
 
@@ -248,38 +249,21 @@ export class AwaySettingsRequest extends BasePayloadRequest {
     }
 
     toBuffer(): Buffer {
-        if (this.heatSetpoint < 15.5 || this.heatSetpoint > 18.5) {
+        if (!Number.isFinite(this.heatSetpoint) || this.heatSetpoint < 15.5 || this.heatSetpoint > 18.5) {
             throw new Error("Heat setpoint must be between 15.5 and 18.5");
         }
 
-        if (this.coolSetpoint < 26.5 || this.coolSetpoint > 29.5) {
+        if (!Number.isFinite(this.coolSetpoint) || this.coolSetpoint < 26.5 || this.coolSetpoint > 29.5) {
             throw new Error("Cool setpoint must be between 26.5 and 29.5");
         }
 
-        const awayHeatMap = {
-            15.5: 0,
-            16: 1,
-            16.5: 2,
-            17: 3,
-            17.5: 4,
-            18: 5,
-            18.5: 5
-        };
-        
-        const awayCoolMap = {
-            26.5: 0,
-            27: 1,
-            27.5: 2,
-            28: 3,
-            28.5: 3,
-            29: 4,
-            29.5: 5
-        };
-
         let payload = Buffer.alloc(3);
         payload.writeUint8(this.fan, 0);
-        payload.writeUint8(awayHeatMap[this.heatSetpoint], 1);
-        payload.writeUint8(awayCoolMap[this.coolSetpoint], 2);
+        // The wire encodes only the 6 indexed values; valid-range inputs can
+        // fall off the 0.5° grid (e.g. unit-converted UI values), so snap to
+        // the nearest table entry instead of an exact-key lookup.
+        payload.writeUint8(nearestAwayIndex(AWAY_HEAT_SETPOINTS_C, this.heatSetpoint), 1);
+        payload.writeUint8(nearestAwayIndex(AWAY_COOL_SETPOINTS_C, this.coolSetpoint), 2);
         return payload;
     }
 }

--- a/tests/functional-domain-scheduling.test.ts
+++ b/tests/functional-domain-scheduling.test.ts
@@ -75,6 +75,47 @@ describe("Scheduling domainx", () => {
             req.coolSetpoint = 26.5;
             expect(() => req.toBuffer()).toThrow();
         });
+
+        it("snaps in-range off-grid setpoints to the nearest wire index", () => {
+            // Valid range but between table entries (e.g. unit-converted UI values)
+            const cases: Array<[number, number, number, number]> = [
+                // [heat °C, cool °C, expected heat index, expected cool index]
+                [15.7, 26.6, 0, 0],   // nearest 15.5 / 26.5
+                [16.2, 27.2, 1, 1],   // nearest 16 / 27
+                [18, 28, 5, 3],       // ties round up: 18.5 / 28.5 (legacy map behavior)
+                [18.4, 29.1, 5, 4],   // nearest 18.5 / 29
+            ];
+            for (const [heat, cool, heatIndex, coolIndex] of cases) {
+                const req = new AwaySettingsRequest();
+                req.fan = FanModeSetting.Auto;
+                req.heatSetpoint = heat;
+                req.coolSetpoint = cool;
+                const buf = req.toBuffer();
+                expect(buf[1]).toBe(heatIndex);
+                expect(buf[2]).toBe(coolIndex);
+            }
+        });
+
+        it("rejects undefined/NaN setpoints instead of writing garbage", () => {
+            const req = new AwaySettingsRequest();
+            req.fan = FanModeSetting.Auto;
+            // setpoints left undefined
+            expect(() => req.toBuffer()).toThrow();
+        });
+
+        it("clamps out-of-range wire indices when parsing (never undefined)", () => {
+            const res = new AwaySettingsResponse(Buffer.from([FanModeSetting.Auto, 9, 250]));
+            expect(res.heatSetpoint).toBe(18.5);
+            expect(res.coolSetpoint).toBe(29.5);
+        });
+
+        it("stamps responses with a numeric timestamp", () => {
+            const before = Date.now();
+            const res = new AwaySettingsResponse(Buffer.from([FanModeSetting.Auto, 0, 0]));
+            expect(typeof res.timestamp).toBe("number");
+            expect(res.timestamp).toBeGreaterThanOrEqual(before);
+            expect(res.timestamp).toBeLessThanOrEqual(Date.now());
+        });
     });
 
     describe(" Schedule Hold ", () => {


### PR DESCRIPTION
## What changed

Fixes items 7 and 8 from the codebase review (the last two known bugs from that pass). No wire-format changes for previously-working inputs.

**`BasePayloadResponse.timestamp`** (`src/BasePayloadResponse.ts`)
- `timestamp = Date.now` assigned the function reference instead of calling it. Every parsed response now carries a real numeric creation time.

**Away Settings index maps** (`src/FunctionalDomainScheduling.ts`)
- `AwaySettingsRequest.toBuffer()` validated setpoints as continuous ranges (15.5–18.5 / 26.5–29.5 °C) but then used exact-key map lookups — any in-range value off the 0.5° grid (e.g. a Fahrenheit-converted UI value like 61.2°F) passed validation and crashed on `writeUint8(undefined)`. Writes now snap to the nearest wire index; ties round up, which exactly preserves the legacy map's explicit 18→18.5 and 28→28.5 mappings, and all on-grid encodings are byte-identical to before.
- Undefined/NaN setpoints now fail the validation throw (`Number.isFinite`) instead of slipping past the range comparison.
- `AwaySettingsResponse` clamps out-of-range wire indices to the table bounds, so parsed setpoints are always numbers, never `undefined`.
- The duplicated inline maps are replaced by shared exported tables `AWAY_HEAT_SETPOINTS_C` / `AWAY_COOL_SETPOINTS_C` (guide §3.2).

## Tests

Four new cases in the existing protocol suite (`tests/functional-domain-scheduling.test.ts`): off-grid snapping incl. tie rounding, undefined-setpoint rejection, response index clamping, and numeric timestamp. Full suite: 208/208 passing; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)