### PR TITLE
Clean up review small notes: stale docs, socket default, mode comment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,8 @@ src/
 
 tests/                               # Protocol unit tests
 tools/aprilaire-proxy/               # Standalone TCP proxy for thermostat debugging
-.github/workflows/npm-publish.yml    # CI: build verification + npm publish on release
+.github/workflows/ci.yml             # CI: tests + production build on every PR / push to main
+.github/workflows/npm-publish.yml    # Release: build, test, publish to GitHub Packages
 ```
 
 ## Protocol documentation
@@ -144,9 +145,11 @@ Utility functions: `convertTemperatureToByte()` and `convertByteToTemperature()`
 
 ## CI/CD
 
-- **Trigger**: GitHub release creation
-- **Pipeline**: `npm ci` build verification, then `npm publish --access=public` to npm
-- **Node version**: 20
+Two workflows in `.github/workflows/`, both on Node 22:
+
+- **`ci.yml`** — every pull request and push to `main`: `npm ci`, unit tests, production webpack bundle, and `dist/plugin.zip` artifact verification.
+- **`npm-publish.yml`** — GitHub release (or manual dispatch): same build + tests, then publishes to **GitHub Packages** as `@nberardi/scrypted-aprilaire` using `GITHUB_TOKEN`. It does **not** publish to npmjs.org.
+- **npmjs.org** (`scrypted-aprilaire`) is published locally when needed: `npm run publish:npmjs` (requires OTP).
 
 ## Important Notes for AI Assistants
 

--- a/src/AprilaireClient.ts
+++ b/src/AprilaireClient.ts
@@ -968,7 +968,8 @@ class AprilaireSocket extends EventEmitter {
     port: number;
     
     private client: net.Socket;
-    private _connected: boolean = true;
+    /** False until the socket's "ready" event; setupSocket() resets it on reconnect. */
+    private _connected: boolean = false;
     /** Sticky TCP receive buffer: retains incomplete frame tails across `data` events. */
     private receiveBuffer: Buffer = Buffer.alloc(0);
     private outboundQueue: OutboundRequestQueue;

--- a/src/AprilaireThermostat.ts
+++ b/src/AprilaireThermostat.ts
@@ -594,6 +594,11 @@ export class AprilaireThermostat extends AprilaireThermostatBase implements OnOf
                     tempSettings.mode = ThermostatMode.Heat;
                     break;
                 case TMode.Off:
+                    // Asymmetric on purpose: Scrypted Off and FanOnly both write
+                    // TMode.Off (the protocol has no separate fan-only mode), so
+                    // readback cannot distinguish them. Report FanOnly + on=false:
+                    // `on` carries the power state, and FanOnly keeps the fan
+                    // controls usable while heating/cooling is off.
                     this.on = false;
                     tempSettings.mode = ThermostatMode.FanOnly;
                     break;


### PR DESCRIPTION
## What changed

The three "small notes" from the codebase review — housekeeping, no behavior changes beyond one corrected default:

**CLAUDE.md** — the CI/CD section still described the old pipeline (npmjs publish on release, Node 20). Now documents what actually runs: `ci.yml` (tests + production build on every PR and push to `main`), `npm-publish.yml` (GitHub Packages publish on release via `GITHUB_TOKEN`), and the manual `npm run publish:npmjs` path for npmjs.org — all on Node 22. The project-structure listing gained the `ci.yml` entry.

**`AprilaireSocket._connected`** — initialized to `true`, so the client reported a live connection before any socket existed. Now `false` until the socket's `"ready"` event. In practice `setupSocket()` always reset it before connecting, so this is a latent-footgun fix rather than a live bug: the only observable difference is that `read()`/`write()` called before the first `connect()` now correctly trigger a connect instead of writing into the void.

**`TMode.Off` → `FanOnly` readback** — the mapping asymmetry (Scrypted `Off` and `FanOnly` both write `TMode.Off`; readback always reports `FanOnly` + `on=false`) now has a comment explaining it's deliberate — the protocol has no separate fan-only mode, `on` carries the power state, and `FanOnly` keeps fan controls usable — so the next reader doesn't flag it as a bug.

## Tests

No new tests needed (docs + comment + a default that existing flow always overwrote). Full suite: 208/208 passing; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)